### PR TITLE
add software manager to measure the pre-application-launching qkerne state

### DIFF
--- a/policy.json
+++ b/policy.json
@@ -33,7 +33,8 @@
             "TERM=xterm"
         ],
         "cmd_arg": [
-            "sh"
+            "--config",
+            "/secret/mongod.conf"
         ],
         "config_fils":[
             {

--- a/qkernel/Cargo.lock
+++ b/qkernel/Cargo.lock
@@ -38,21 +38,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aes-gcm-siv"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
-dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "polyval",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "atomic-polyfill"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,12 +499,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hex-literal"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
-
-[[package]]
 name = "hkdf"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,7 +830,6 @@ name = "qkernel"
 version = "0.6.0"
 dependencies = [
  "aes-gcm",
- "aes-gcm-siv",
  "base64",
  "base64ct",
  "bit_field",
@@ -861,7 +839,6 @@ dependencies = [
  "embedded-tls",
  "enum_dispatch",
  "getrandom",
- "hex-literal",
  "hmac",
  "httparse",
  "lazy_static",

--- a/qkernel/Cargo.toml
+++ b/qkernel/Cargo.toml
@@ -19,13 +19,11 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 serde_derive = { version = "1.0.106", default-features = false}
 scopeguard = { version = "^1.1.0", default-features = false }
 enum_dispatch = { git = "https://github.com/QuarkContainer/enum_dispatch_clone.git" }
-aes-gcm-siv = "0.11.1"
 getrandom = { version = "0.2", features = ["rdrand"] }
 aes-gcm = "0.10.1"
 postcard ={ version = "1.0", features = ["alloc"] }
 hmac = "0.12.1"
 sha2 = { version = "0.10.6", default-features = false,  features = ["force-soft"]}
-hex-literal = "0.3.4"
 base64ct = { version = "1.5.3",  features = ["alloc"]}
 modular-bitfield = "0.11.2"
 rand = { version = "0.8.3", features = ["getrandom"], default-features = false }

--- a/qkernel/src/kernel_def.rs
+++ b/qkernel/src/kernel_def.rs
@@ -252,6 +252,7 @@ pub fn StartExecProcess(fd: i32, process: Process) {
     super::StartExecProcess(fd, process)
 }
 pub fn StartSubContainerProcess(elfEntry: u64, userStackAddr: u64, kernelStackAddr: u64) {
+    info!("StartSubContainerProcess");
     super::StartSubContainerProcess(elfEntry, userStackAddr, kernelStackAddr)
 }
 

--- a/qkernel/src/lib.rs
+++ b/qkernel/src/lib.rs
@@ -109,7 +109,6 @@ use self::qlib::kernel::TSC;
 use crate::qlib::kernel::GlobalIOMgr;
 
 use self::qlib::kernel::vcpu::*;
-use ssh_key::Signature;
 use vcpu::CPU_LOCAL;
 
 use core::panic::PanicInfo;
@@ -460,7 +459,6 @@ pub fn InitTsc() {
 
 extern crate hmac;
 extern crate sha2;
-extern crate hex_literal;
 extern crate base64ct;
 
 
@@ -511,7 +509,18 @@ pub extern "C" fn rust_main(
     interrupt::init();
 
     /***************** can't run any qcall before this point ************************************/
-    
+    {
+        let mut measurement_manager = software_measurement_manager::SOFTMEASUREMENTMANAGER.try_write();
+        while !measurement_manager.is_some() {
+            measurement_manager = software_measurement_manager::SOFTMEASUREMENTMANAGER.try_write();
+        }
+
+        let mut measurement_manager = measurement_manager.unwrap();
+        let res = measurement_manager.measure_qkernel_argument(heapStart, shareSpaceAddr, id, vdsoParamAddr, vcpuCnt, autoStart);
+        if res.is_err() {
+            panic!("measure_qkernel_argument got error {:?}", res);
+        }
+    }
 
     if id == 0 {
         //error!("start main: {}", ::AllocatorPrint(10));
@@ -606,6 +615,24 @@ fn StartRootContainer(_para: *const u8) -> ! {
     let task = Task::Current();
     let mut process = Process::default();
     Kernel::HostSpace::LoadProcessKernel(&mut process as * mut _ as u64) as usize;
+
+    {
+        let mut measurement_manager = software_measurement_manager::SOFTMEASUREMENTMANAGER.try_write();
+        while !measurement_manager.is_some() {
+            measurement_manager = software_measurement_manager::SOFTMEASUREMENTMANAGER.try_write();
+        }
+
+        let mut measurement_manager = measurement_manager.unwrap();
+
+
+        let res = measurement_manager.measure_process_spec(&process);
+        if res.is_err() {
+            error!("StartRootContainer measure_process_spec(&processSpec) got error {:?}", res);
+            SHARESPACE.StoreShutdown();
+            Kernel::HostSpace::ExitVM(2);
+            panic!("exiting ...");
+        }
+    }
 
     let (_tid, entry, userStackAddr, kernelStackAddr) = {
         let mut processArgs = LOADER.Lock(task).unwrap().Init(process);

--- a/qkernel/src/shield/https_attestation_provisioning_cli.rs
+++ b/qkernel/src/shield/https_attestation_provisioning_cli.rs
@@ -20,7 +20,7 @@ use crate::aes_gcm::{
     Aes256Gcm, Nonce, // Or `Aes128Gcm`
     Key,
 };
-use crate::shield::sev_guest::{detect_tee_type, GUEST_SEV_DEV, hash_chunks};
+use crate::shield::sev_guest::{detect_tee_type, GUEST_SEV_DEV};
 use alloc::string::ToString;
 use qlib::kernel::task::*;
 use qlib::linux_def::*;
@@ -437,7 +437,7 @@ impl ShieldProvisioningHttpSClient {
             tee_pubkey.k.clone().into_bytes(),  
         ];
 
-        let ehd = hash_chunks(ehd_chunks);
+        let ehd = super::hash_chunks(ehd_chunks);
         let tee_evidence;
 
         {
@@ -879,7 +879,7 @@ fn set_up_tls<'a>(client: &'a ShieldProvisioningHttpSClient, read_record_buffer:
     Ok(tls)
 }
 
-pub fn provisioning_http_client(task: &Task) -> Result<usize> {
+pub fn provisioning_http_client(task: &Task) -> Result<Policy> {
 
     log::trace!("provisioning_http_client start");
 
@@ -945,5 +945,5 @@ pub fn provisioning_http_client(task: &Task) -> Result<usize> {
 
     info!("policy for kbs {:?}", policy);
 
-    Ok(0)
+    Ok(policy)
 }

--- a/qkernel/src/shield/mod.rs
+++ b/qkernel/src/shield/mod.rs
@@ -5,7 +5,7 @@ pub mod exec_shield;
 pub mod inode_tracker;
 pub mod sev_guest;
 pub mod secret_injection;
-
+pub mod software_measurement_manager;
 
 use self::exec_shield::*;
 use self::terminal_shield::*;
@@ -13,7 +13,9 @@ use self::inode_tracker::*;
 use qlib::shield_policy::*;
 use crate::aes_gcm::{ Aes256Gcm, Key};
 use self::sev_guest::GUEST_SEV_DEV;
-
+use sha2::{Sha512, Digest};
+use base64ct::{Base64, Encoding};
+use alloc::{vec::Vec, string::String};
 
 
 pub fn init_shielding_layer (policy: Option<&Policy>) ->() {
@@ -49,3 +51,19 @@ pub fn init_shielding_layer (policy: Option<&Policy>) ->() {
 
     
 }
+
+
+// Returns a base64 of the sha512 of all chunks.
+pub fn hash_chunks(chunks: Vec<Vec<u8>>) -> String {
+	let mut hasher = Sha512::new();
+
+	for chunk in chunks.iter() {
+		hasher.update(chunk);
+	}
+
+	let res = hasher.finalize();
+
+	let base64 = Base64::encode_string(&res);
+
+	base64
+} 

--- a/qkernel/src/shield/sev_guest.rs
+++ b/qkernel/src/shield/sev_guest.rs
@@ -13,7 +13,6 @@ use alloc::string::ToString;
 use spin::rwlock::RwLock;
 use qlib::kernel::SHARESPACE;
 use qlib::kernel::Kernel::HostSpace;
-use sha2::{Sha512, Digest};
 use base64ct::{Base64, Encoding};
 use alloc::string::String;
 use super::https_attestation_provisioning_cli::Tee;
@@ -542,21 +541,6 @@ impl SnpGuestDev {
 
 
 }
-
-// Returns a base64 of the sha512 of all chunks.
-pub fn hash_chunks(chunks: Vec<Vec<u8>>) -> String {
-	let mut hasher = Sha512::new();
-
-	for chunk in chunks.iter() {
-		hasher.update(chunk);
-	}
-
-	let res = hasher.finalize();
-
-	let base64 = Base64::encode_string(&res);
-
-	base64
-} 
 
 fn vec_to_array<T, const N: usize>(v: Vec<T>) -> [T; N] {
     v.try_into()

--- a/qkernel/src/shield/software_measurement_manager.rs
+++ b/qkernel/src/shield/software_measurement_manager.rs
@@ -1,0 +1,186 @@
+use alloc::vec::Vec;
+use spin::rwlock::RwLock;
+use alloc::string::{String, ToString};
+use crate::qlib::common::*;
+use qlib::addr::Addr;
+use crate::qlib::kernel::task::Task;
+use crate::qlib::loader::Process;
+use qlib::auxv::AuxEntry;
+
+
+const APP_NMAE: &str = "APPLICATION_NAME"; 
+
+lazy_static! {
+    pub static ref SOFTMEASUREMENTMANAGER:  RwLock<SoftwareMeasurementManager> = RwLock::new(SoftwareMeasurementManager::default());
+}
+
+#[derive(Debug, Default, Serialize)]
+struct QKernelArgs {
+    heapStart: u64, 
+    shareSpaceAddr: u64, 
+    id: u64, 
+    svdsoParamAddr: u64, 
+    vcpuCnt: u64, 
+    autoStart: bool
+}
+
+
+#[derive(Debug, Default)]
+pub struct SoftwareMeasurementManager {
+    containerlized_app_name: String,
+    is_app_loaded: bool,
+    //  a base64 of the sha512
+    measurement : String,
+}
+
+
+
+fn get_application_name(envs : Vec<String>) -> Option<String>{
+
+    if envs.len() == 0 {
+        return  None;
+    }
+
+    for env in envs {
+
+        let key_value:  Vec<&str> = env.split('=').collect();
+
+        assert!(key_value.len() == 2);
+        if key_value[0].eq(APP_NMAE) {
+            return Some(key_value[1].to_string());
+        }
+    }
+
+    None
+}
+
+impl SoftwareMeasurementManager {
+
+    fn updata_measurement(&mut self, new_data: Vec<u8>) -> Result<()> {
+
+        let chunks = vec![
+            self.measurement.as_bytes().to_vec(),
+            new_data,  
+        ];
+
+        let hash_res = super::hash_chunks(chunks);
+
+        self.measurement = hash_res;
+
+        Ok(())
+    }
+
+    pub fn is_application_loaded (&self) -> Result<bool> {
+        return Ok(self.is_app_loaded);
+    }
+
+    pub fn set_application_loaded (&mut self) -> Result<()> {
+        self.is_app_loaded = true;
+        return Ok(());
+    }
+
+    pub fn get_application_name (&self) -> Result<&str> {
+        return Ok(&self.containerlized_app_name);
+    }
+
+    pub fn measure_process_spec(&mut self, proc_spec: &Process) -> Result<()> {
+
+        let proccess_spec_vec = serde_json::to_vec(proc_spec);
+        if proccess_spec_vec.is_err() {
+            info!("measure_process_spec serde_json::to_vec(proc_spec) get error");
+            return Err(Error::Common("measure_process_spec serde_json::to_vec(proc_spec) get error".to_string()));
+        }
+
+        let proccess_spec_vec_in_bytes = proccess_spec_vec.unwrap();
+
+        self.updata_measurement(proccess_spec_vec_in_bytes).unwrap();
+
+        Ok(())
+    }
+
+    pub fn set_application_name(&mut self, envs: &Vec<String>) -> Result<()> {
+
+        let app_name = get_application_name(envs.clone());
+        if app_name.is_none() {
+            info!("set_application_name get_application_name return none");
+            return Err(Error::Common("set_application_name get_application_name return none".to_string()));
+        }
+
+        self.containerlized_app_name = app_name.unwrap();
+
+        Ok(())
+    }
+
+    pub fn measure_qkernel_argument (&mut self, heapStart: u64, shareSpaceAddr: u64, id: u64, svdsoParamAddr: u64, vcpuCnt: u64, autoStart: bool) ->  Result<()> {
+
+        let qkernel_args = QKernelArgs {
+            heapStart: heapStart,
+            shareSpaceAddr: shareSpaceAddr,
+            id: id,
+            svdsoParamAddr: svdsoParamAddr,
+            vcpuCnt: vcpuCnt,
+            autoStart: autoStart,
+        };
+
+        let kernel_args_in_bytes = serde_json::to_vec(&qkernel_args)
+            .map_err(|e| Error::Common(format!("measure_qkernel_argument, serde_json::to_vec(&qkernel_args) get error {:?}", e)))?;
+
+        self.updata_measurement(kernel_args_in_bytes).unwrap();
+
+        Ok(())
+    }
+
+    /**
+     *  Only measure the auxv we got from elf file is enough,
+     *  Other data like, envv, argv, are measuared by `measure_process_spec`
+     */
+    pub fn measure_stack(&mut self, auxv: Vec<AuxEntry>) -> Result<()> {
+
+        let mut aux_entries_in_byte = Vec::new();
+        for entry in auxv {
+            let mut entry_in_byte = serde_json::to_vec(&entry)
+                .map_err(|e| Error::Common(format!("measure_stack, serde_json::to_vec(&entry) get error {:?}", e)))?;
+            aux_entries_in_byte.append(&mut entry_in_byte);
+        }
+
+        self.updata_measurement(aux_entries_in_byte).unwrap();
+
+        Ok(())
+    }
+
+    pub fn measure_elf_loadable_segment(&mut self, load_segment_virtual_addr: u64, load_segment_size: u64, offset: u64, task: &Task) -> Result<()> {
+
+        let startMem = Addr(load_segment_virtual_addr).RoundDown().unwrap();
+        let endMem = Addr(load_segment_virtual_addr)
+                .AddLen(load_segment_size).unwrap()
+                .RoundUp().unwrap();
+        let len = endMem.0 - startMem.0;
+        
+        let vma_start = startMem.0 + offset;
+        let data: Result<Vec<u8>> =  task.CopyInVec(vma_start, len as usize);
+        if data.is_err() {
+            info!("After MapSegment copy elf loadable segment got error {:?}", data);
+            return Err(data.err().unwrap());
+        }
+
+        let loadable = data.unwrap();
+
+        self.updata_measurement(loadable).unwrap();
+    
+        Ok(())
+    }
+
+    pub fn measure_shared_lib(&mut self) -> Result<()> {
+
+        Ok(())
+    }
+
+    pub fn get_measurement(&self) -> Result<String> {
+
+        Ok(self.measurement.clone())
+    }
+
+}
+
+
+

--- a/qkernel/src/syscalls/sys_attestation_report.rs
+++ b/qkernel/src/syscalls/sys_attestation_report.rs
@@ -101,7 +101,7 @@ pub fn SysAttestationReport(task: &mut Task, args: &SyscallArguments) -> Result<
         user_data_unwrap
     ];
 
-    let encode64_user_data = sev_guest::hash_chunks(user_data_chunks);
+    let encode64_user_data = crate::shield::hash_chunks(user_data_chunks);
     match sev_guest::detect_tee_type() {
         https_attestation_provisioning_cli::Tee::Snp => {
 

--- a/qkernel/src/syscalls/sys_thread.rs
+++ b/qkernel/src/syscalls/sys_thread.rs
@@ -189,7 +189,7 @@ pub fn Execvat(task: &mut Task, dirfd: i32, filenameAddr: u64, argvAddr: u64, en
         }
     
         let mut argv = task.CopyInVector(argvAddr, EXEC_MAX_ELEM_SIZE, EXEC_MAX_TOTAL_SIZE as i32)?;
-        let envv = task.CopyInVector(envvAddr, EXEC_MAX_ELEM_SIZE, EXEC_MAX_TOTAL_SIZE as i32)?;
+        let mut envv = task.CopyInVector(envvAddr, EXEC_MAX_ELEM_SIZE, EXEC_MAX_TOTAL_SIZE as i32)?;
     
         if argv.len() == 0 {
             argv.push(fileName.clone())
@@ -344,7 +344,7 @@ pub fn Execvat(task: &mut Task, dirfd: i32, filenameAddr: u64, argvAddr: u64, en
         }
     
         let extraAxv = Vec::new();
-        Load(task, &fileName, &mut argv, &envv, &extraAxv, false)?
+        Load(task, &fileName, &mut argv, &mut envv, &extraAxv, false)?
     };
     
     //need to clean object on stack before enter_user as the stack will be destroyed

--- a/qlib/auxv.rs
+++ b/qlib/auxv.rs
@@ -1,5 +1,5 @@
 #[allow(non_camel_case_types)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Serialize)]
 pub enum AuxVec {
     AT_NULL = 0,
 
@@ -74,7 +74,7 @@ pub enum AuxVec {
     AT_SYSINFO_EHDR = 33,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Serialize)]
 pub struct AuxEntry {
     pub Key: AuxVec,
     pub Val: u64,

--- a/qlib/kernel/boot/controller.rs
+++ b/qlib/kernel/boot/controller.rs
@@ -21,10 +21,6 @@ use crate::qlib::kernel::Kernel::HostSpace;
 use crate::qlib::kernel::kernel::kernel::GetKernel;
 //use crate::qlib::mem::list_allocator::*;
 use crate::qlib::linux::signal::*;
-use crate::shield::sev_guest;
-// use super::super::super::super::kernel_def::{
-//     StartExecProcess, StartRootContainer, StartSubContainerProcess, POLICY_CHEKCER
-// };
 use super::super::super::common::*;
 use super::super::super::control_msg::*;
 use super::super::super::vcpu_mgr::*;
@@ -254,7 +250,7 @@ pub fn ControlMsgHandler(fd: *const u8) {
                         "1238129edjcakhvsjakjaskjsajlkjlksank".as_bytes().to_vec(),
                     ];
     
-                    let report_data = sev_guest::hash_chunks(user_data);
+                    let report_data = crate::shield::hash_chunks(user_data);
     
                     report = attester.get_report(report_data);
                     if  report.is_err() {

--- a/qlib/kernel/boot/loader.rs
+++ b/qlib/kernel/boot/loader.rs
@@ -44,7 +44,7 @@ use super::super::SignalDef::*;
 use super::super::SHARESPACE;
 use super::fs::*;
 use crate::qlib::shield_policy::*;
-use crate::shield::{exec_shield::*, secret_injection};
+use crate::shield::{exec_shield::*, secret_injection, software_measurement_manager};
 use crate::qlib::kernel::boot::config;
 
 impl Process {
@@ -267,7 +267,7 @@ impl Loader {
             &paths,
         )?;
         let (entry, userStackAddr, kernelStackAddr) =
-            kernel.LoadProcess(&procArgs.Filename, &procArgs.Envv, &mut procArgs.Argv, false)?;
+            kernel.LoadProcess(&procArgs.Filename, &mut procArgs.Envv, &mut procArgs.Argv, false)?;
         return Ok((tid, entry, userStackAddr, kernelStackAddr));
     }
 
@@ -344,7 +344,7 @@ impl Loader {
         );
 
         let (entry, userStackAddr, kernelStackAddr) =
-            kernel.LoadProcess(&procArgs.Filename, &procArgs.Envv, &mut procArgs.Argv, false)?;
+            kernel.LoadProcess(&procArgs.Filename, &mut procArgs.Envv, &mut procArgs.Argv, false)?;
         return Ok((tid, entry, userStackAddr, kernelStackAddr));
     }
 
@@ -377,6 +377,24 @@ impl Loader {
     pub fn StartSubContainer(&self, processSpec: Process) -> Result<(i32, u64, u64, u64)> {
 
         info!("StartSubContainer");
+        {
+            let mut measurement_manager = software_measurement_manager::SOFTMEASUREMENTMANAGER.try_write();
+            while !measurement_manager.is_some() {
+                measurement_manager = software_measurement_manager::SOFTMEASUREMENTMANAGER.try_write();
+            }
+
+            let mut measurement_manager = measurement_manager.unwrap();
+
+
+            measurement_manager.set_application_name(&processSpec.Envs)?;
+
+            let res = measurement_manager.measure_process_spec(&processSpec);
+            if res.is_err() {
+                info!("StartSubContainer measure_process_spec(&processSpec) got error {:?}", res);
+                return Err(res.err().unwrap());
+            }
+        }
+
         let task = Task::Current();
         let mut lockedLoader = self.Lock(task)?;
         let kernel = lockedLoader.kernel.clone();
@@ -406,10 +424,8 @@ impl Loader {
             Some(&processSpec.TaskCaps()),
             &userns,
         );
-        info!("InitRootFs before");
         let rootMounts = InitRootFs(Task::Current(), &processSpec.Root)
             .expect("in loader::StartSubContainer, InitRootfs fail");
-        info!("InitRootFs after");
 
         let config = config::Config {
             RootDir: processSpec.Root.clone(),
@@ -418,11 +434,11 @@ impl Loader {
 
         // assume only 1 container possible
         {   
-            info!("secret_injection::FileSystemMount::init before");
+            debug!("secret_injection::FileSystemMount::init before");
             let secrets_mount_info = secret_injection::FileSystemMount::init(config, rootMounts.Root(), rootMounts.clone());
             let mut secret_injector =  secret_injection::SECRET_KEEPER.write();
             secret_injector.set_secrets_mount_info(secrets_mount_info).unwrap();
-            info!("secret_injection::FileSystemMount::init after");
+            debug!("secret_injection::FileSystemMount::init after");
         }
 
         kernel
@@ -499,9 +515,12 @@ impl Loader {
             &createProcessArgs.Filename,
             &paths,
         )?;
+
+    
+        
         let (entry, userStackAddr, kernelStackAddr) = kernel.LoadProcess(
             &createProcessArgs.Filename,
-            &createProcessArgs.Envv,
+            &mut createProcessArgs.Envv,
             &mut createProcessArgs.Argv,
             true
         )?;

--- a/qlib/kernel/fs/host/diriops.rs
+++ b/qlib/kernel/fs/host/diriops.rs
@@ -351,7 +351,7 @@ impl InodeOperations for HostDirOp {
 
     fn Lookup(&self, task: &Task, parent: &Inode, name: &str) -> Result<Dirent> {
 
-        info!("HostDirOp open host file: {:?}", name);
+        //info!("HostDirOp open host file: {:?}", name);
         let (fd, writeable, fstat) = match TryOpenAt(self.HostFd(), name) {
             Err(Error::SysError(SysErr::ENOENT)) => {
                 let inode = match self.lock().overrides.get(name) {

--- a/qlib/kernel/fs/host/hostinodeop.rs
+++ b/qlib/kernel/fs/host/hostinodeop.rs
@@ -642,6 +642,8 @@ impl HostInodeOp {
         offset: i64,
         _blocking: bool,
     ) -> Result<i64> {
+
+        info!("Hostinode ReadAt");
         let hostIops = self.clone();
 
         let size = IoVec::NumBytes(dsts);
@@ -943,6 +945,8 @@ impl HostInodeOp {
         writeable: bool,
     ) -> Result<()> {
         self.lock().hasMappable = true;
+
+        info!("AddMapping start virtual addr {:x}, end virtual address {:x}, len {:x}, offset {:x}, writeable {:?}", ar.start, ar.End(), ar.Len(),  offset, writeable);
 
         // todo: if there is bufwrite ongoing, should we wait for it?
         /*let _= if self.BufWriteEnable() {

--- a/qlib/kernel/fs/inode.rs
+++ b/qlib/kernel/fs/inode.rs
@@ -605,7 +605,7 @@ impl Inode {
     pub fn Lookup(&self, task: &Task, name: &str) -> Result<Dirent> {
         let isOverlay = self.lock().Overlay.is_some();
         if isOverlay {
-            info!("Lookup isoverlay: {:?}", name);
+            // info!("Lookup isoverlay: {:?}", name);
             let overlay = self.lock().Overlay.as_ref().unwrap().clone();
             let (dirent, _) = overlayLookup(task, &overlay, self, name)?;
             return Ok(dirent);
@@ -613,7 +613,7 @@ impl Inode {
         
         let iops = self.lock().InodeOp.clone();
         let res = iops.Lookup(task, self, name);
-        info!("Lookup overlay: 1111 {:?}", name);
+        // info!("Lookup overlay: 1111 {:?}", name);
         return res;
     }
 

--- a/qlib/kernel/fs/inode_overlay.rs
+++ b/qlib/kernel/fs/inode_overlay.rs
@@ -81,14 +81,14 @@ pub fn overlayLookup(
             Err(e) => return Err(e),
         }
 
-        info!("overlayLookup, name {:?}", name);
+        //info!("overlayLookup, name {:?}", name);
 
         if OverlayHasWhiteout(task, &upper, name) {
             if upperInode.is_none() {
                 return Err(Error::SysError(SysErr::ENOENT));
             }
 
-            info!("OverlayHasWhiteout, name {:?}", name);
+            //info!("OverlayHasWhiteout, name {:?}", name);
             let entry = OverlayEntry::New(task, upperInode, None, false)?;
             let oinode = NewOverlayInode(task, entry, &inode.lock().MountSource);
             let d = Dirent::New(&oinode, name);
@@ -96,17 +96,17 @@ pub fn overlayLookup(
         }
     }
 
-    info!("lower, name {:?}", name);
+    //info!("lower, name {:?}", name);
     if parent.lower.is_some() {
         let lower = parent.lower.as_ref().unwrap().clone();
-        info!("overlayLookup reach 0{:?}", name);
+        //info!("overlayLookup reach 0{:?}", name);
         match lower.Lookup(task, name) {
             Ok(child) => {
                 if upperInode.is_none() {
-                    info!("lower.Lookup(task, name) a{:?}", name);
+                    //info!("lower.Lookup(task, name) a{:?}", name);
                     lowerInode = Some(child.Inode());
                 } else {
-                    info!("lower.Lookup(task, name) b{:?}", name);
+                    //info!("lower.Lookup(task, name) b{:?}", name);
                     let childInode = child.Inode();
                     if upperInode.as_ref().unwrap().StableAttr().Type
                         == childInode.StableAttr().Type
@@ -124,7 +124,7 @@ pub fn overlayLookup(
         }
     }
 
-    info!("overlayLookup reach 1{:?} name,upperInode.is_some() {:?} lowerInode.is_some(): {:?}", name,upperInode.is_some() ,lowerInode.is_some());
+    //info!("overlayLookup reach 1{:?} name,upperInode.is_some() {:?} lowerInode.is_some(): {:?}", name,upperInode.is_some() ,lowerInode.is_some());
 
     if upperInode.is_none() && lowerInode.is_none() {
         return Err(Error::SysError(SysErr::ENOENT));

--- a/qlib/kernel/fs/mount.rs
+++ b/qlib/kernel/fs/mount.rs
@@ -357,14 +357,14 @@ impl MountNs {
         if path.len() == 0 {
             return Err(Error::SysError(SysErr::ENOENT));
         }
-        info!("FindDirent, path {:?}, root {:?}", path, root.Name());
+        //info!("FindDirent, path {:?}, root {:?}", path, root.Name());
 
         let (mut current, mut first, mut remain) = match self.InitPath(root, &wd, path) {
             None => return Ok(root.clone()),
             Some(res) => res,
         };
 
-        info!("FindDirent, current {:?}, first {:?}, remain{:?}", current.Name(), first, remain);
+        //info!("FindDirent, current {:?}, first {:?}, remain{:?}", current.Name(), first, remain);
 
         let mut remainStr;
 

--- a/qlib/kernel/fs/ramfs/dir.rs
+++ b/qlib/kernel/fs/ramfs/dir.rs
@@ -241,7 +241,7 @@ impl InodeOperations for Dir {
         if name.len() > NAME_MAX {
             return Err(Error::SysError(SysErr::ENAMETOOLONG));
         }
-        info!("Dir Inode Lookup name {:?}", name);
+        //info!("Dir Inode Lookup name {:?}", name);
 
         let d = self.read();
 

--- a/qlib/kernel/kernel/kernel.rs
+++ b/qlib/kernel/kernel/kernel.rs
@@ -402,7 +402,7 @@ impl Kernel {
     pub fn LoadProcess(
         &self,
         fileName: &str,
-        envs: &Vec<String>,
+        envs: &mut Vec<String>,
         args: &mut Vec<String>,
         isSubContainer: bool
     ) -> Result<(u64, u64, u64)> {

--- a/qlib/kernel/memmgr/vma.rs
+++ b/qlib/kernel/memmgr/vma.rs
@@ -260,7 +260,7 @@ impl MemoryManager {
             Map32Bit: opts.Map32Bit,
             Kernel: opts.Kernel,
         };
-        let addr = self.FindAvailableLocked(opts.Length, &mut findopts)?;
+        let addr = self.FindAvailableLocked(opts.Length, &mut findopts)?;   // return start virtual address of avialiable range
 
         let ar = Range::New(addr, opts.Length);
 

--- a/qvisor/src/shield/mod.rs
+++ b/qvisor/src/shield/mod.rs
@@ -5,6 +5,7 @@ pub mod exec_shield;
 pub mod inode_tracker;
 pub mod sev_guest;
 pub mod secret_injection;
+pub mod software_measurement_manager;
 
 
 use self::exec_shield::*;
@@ -38,12 +39,11 @@ pub fn init_shielding_layer (policy: Option<&Policy>) ->() {
 
     let mut exec_access_control = EXEC_AUTH_AC.write();
     exec_access_control.init(&KEY_SLICE.to_vec(), &encryption_key, policy);
-
-
-
-
     // init sev guest driver
     GUEST_SEV_DEV.write().init(0);
 
     
 }
+pub fn hash_chunks(_chunks: Vec<Vec<u8>>) -> String {
+	return "".to_string();
+} 

--- a/qvisor/src/shield/sev_guest.rs
+++ b/qvisor/src/shield/sev_guest.rs
@@ -556,9 +556,7 @@ impl SnpGuestDev {
 	} 
 }
 
-pub fn hash_chunks(_chunks: Vec<Vec<u8>>) -> String {
-	return "".to_string();
-} 
+
 
 
 fn vec_to_array<T, const N: usize>(v: Vec<T>) -> [T; N] {

--- a/qvisor/src/shield/software_measurement_manager.rs
+++ b/qvisor/src/shield/software_measurement_manager.rs
@@ -1,0 +1,89 @@
+use alloc::vec::Vec;
+use spin::rwlock::RwLock;
+use alloc::string::String;
+use crate::qlib::common::*;
+use crate::qlib::kernel::task::Task;
+use crate::qlib::loader::Process;
+use crate::qlib::auxv::AuxEntry;
+
+
+const APP_NMAE: &str = "APPLICATION_NAME"; 
+
+lazy_static! {
+    pub static ref SOFTMEASUREMENTMANAGER:  RwLock<SoftwareMeasurementManager> = RwLock::new(SoftwareMeasurementManager::default());
+}
+
+#[derive(Debug, Default, Serialize)]
+struct QKernelArgs {
+    heapStart: u64, 
+    shareSpaceAddr: u64, 
+    id: u64, 
+    svdsoParamAddr: u64, 
+    vcpuCnt: u64, 
+    autoStart: bool
+}
+
+
+#[derive(Debug, Default)]
+pub struct SoftwareMeasurementManager {
+    containerlized_app_name: String,
+    is_app_loaded: bool,
+    //  a base64 of the sha512
+    measurement : String,
+}
+
+impl SoftwareMeasurementManager {
+
+    fn updata_measurement(&mut self, _new_data: Vec<u8>) -> Result<()> {
+        Err(Error::NotSupport)
+    }
+
+    pub fn measure_process_spec(&mut self, _proc_spec: &Process) -> Result<()> {
+        Err(Error::NotSupport)
+    }
+
+    pub fn set_application_name(&mut self, _envs: &Vec<String>) -> Result<()> {
+        Err(Error::NotSupport)
+    }
+
+    pub fn measure_qkernel_argument (&mut self, _heapStart: u64, _shareSpaceAddr: u64, _id: u64, _svdsoParamAddr: u64, _vcpuCnt: u64, _autoStart: bool) ->  Result<()> {
+        Err(Error::NotSupport)
+    }
+
+    /**
+     *  Only measure the auxv we got from elf file is enough,
+     *  Other data like, envv, argv, are measuared by `measure_process_spec`
+     */
+    pub fn measure_stack(&mut self, _auxv: Vec<AuxEntry>) -> Result<()> {
+        Err(Error::NotSupport)
+    }
+
+    pub fn measure_elf_loadable_segment(&mut self, _load_segment_virtual_addr: u64, _load_segment_size: u64, _offset: u64, _task: &Task) -> Result<()> {
+        Err(Error::NotSupport)
+    }
+
+    pub fn measure_shared_lib(&mut self) -> Result<()> {
+        Err(Error::NotSupport)
+    }
+
+    pub fn get_measurement(&self) -> Result<String> {
+        Err(Error::NotSupport)
+    }
+
+    
+    pub fn is_application_loaded (&self) -> Result<bool> {
+        Err(Error::NotSupport)
+    }
+
+    pub fn set_application_loaded (&self) -> Result<()> {
+        Err(Error::NotSupport)
+    }
+
+    pub fn get_application_name (&self) -> Result<&str> {
+        Err(Error::NotSupport)
+    }
+
+}
+
+
+


### PR DESCRIPTION

The measurement includes: 
- the loadable segments of  executables that qkernel loaded from host, such as script interpreter, scripts, binary
- qkernel args
- the process section of OCI runtime spec loaded from host (qkernel initializes container application process based on it)
- stack of each process launched by qkernel
Currently, we are still missing the measurement for shared libs