### PR TITLE
track app build process

### DIFF
--- a/qkernel/src/shield/guest_syscall_interceptor.rs
+++ b/qkernel/src/shield/guest_syscall_interceptor.rs
@@ -29,14 +29,23 @@ pub fn syscall_interceptor_policy_update(policy: &BackEndSyscallInterceptorConfi
 }
 
 
-pub fn syscall_interceptor_init(policy: BackEndSyscallInterceptorConfig, application_pid: i32) -> Result<()> {
+pub fn syscall_interceptor_init(policy: BackEndSyscallInterceptorConfig) -> Result<()> {
 
     let mut syscall_info_keeper = SYSCALLINTERCEPTOR.write();
 
-    debug!("syscall_interceptor_init policy {:?}, task id {:?}", policy, application_pid);
+    debug!("syscall_interceptor_init policy {:?}", policy);
     syscall_info_keeper.policy = policy;
-    syscall_info_keeper.application_pid = application_pid;
     syscall_info_keeper.is_init = true;
+
+    Ok(())
+}
+
+pub fn syscall_interceptor_set_app_pid(application_pid: i32) -> Result<()> {
+
+    let mut syscall_info_keeper = SYSCALLINTERCEPTOR.write();
+
+    debug!("syscall_interceptor_set_app_pid pid {:?}", application_pid);
+    syscall_info_keeper.application_pid = application_pid;
 
     Ok(())
 }

--- a/qkernel/src/shield/secret_injection.rs
+++ b/qkernel/src/shield/secret_injection.rs
@@ -10,6 +10,7 @@ use crate::qlib::kernel::boot::fs::MountSubmounts;
 use qlib::common::*;
 use alloc::collections::btree_map::BTreeMap;
 use alloc::string::String;
+use shield::EnvCmdBasedSecrets;
 
 lazy_static! {
     pub static ref SECRET_KEEPER:  RwLock<SecretKeeper> = RwLock::new(SecretKeeper::default());
@@ -22,6 +23,7 @@ pub struct SecretKeeper {
     initialized: bool,
     pub secrets_mount_info: FileSystemMount,
     pub file_secrets:  BTreeMap<String, Vec<u8>>,  // key: file name, value: secret
+    pub arg_env_based_secrets: Option<EnvCmdBasedSecrets>,
 }
 
 
@@ -34,9 +36,11 @@ impl SecretKeeper {
         Ok(())
     }
 
-    pub fn bookkeep_file_based_secret (&mut self, secrets: KbsSecrets) -> Result<()> {
+    pub fn bookkeep_secrets (&mut self, secrets: KbsSecrets) -> Result<()> {
 
-        info!("file_based_secret_injection");
+        info!("bookkeep_secrets");
+
+        self.arg_env_based_secrets = secrets.env_cmd_secrets;
 
         if secrets.config_fils.is_none() {
             return Ok(());

--- a/qlib/kernel/loader/loader.rs
+++ b/qlib/kernel/loader/loader.rs
@@ -280,6 +280,21 @@ pub fn Load(
 ) -> Result<(u64, u64, u64)> {
     let vdsoAddr = LoadVDSO(task)?;
 
+    let mut name = Base(&filename);
+    if name.len() > TASK_COMM_LEN - 1 {
+        name = &name[0..TASK_COMM_LEN - 1];
+    }
+
+    let app_name;
+    let app_loaded;
+    {
+        let app_info_keeper = APPLICATION_INFO_KEEPER.read();
+
+        app_name = app_info_keeper.get_application_name().unwrap().to_string();
+        app_loaded = app_info_keeper.is_application_loaded().unwrap();
+    }
+
+
     info!("start load isSubContainer {:?}, file name {:?} is mongond {:?}, argv {:?}, envv {:?}", isSubContainer, filename, filename.eq("/usr/bin/mongod"), argv, envv);
 
     let (loaded, executable, tmpArgv) = LoadExecutable(task, filename, argv)?;
@@ -290,10 +305,6 @@ pub fn Load(
     task.mm.BrkSetup(e);
     task.mm.SetExecutable(&executable);
 
-    let mut name = Base(&filename);
-    if name.len() > TASK_COMM_LEN - 1 {
-        name = &name[0..TASK_COMM_LEN - 1];
-    }
 
     task.thread.as_ref().unwrap().lock().name = name.to_string();
 
@@ -311,7 +322,7 @@ pub fn Load(
 
         let mut measurement_manager = measurement_manager.unwrap();
 
-        let res = measurement_manager.measure_stack(loaded.auxv.clone());
+        let res = measurement_manager.measure_stack(loaded.auxv.clone(), app_name.eq(name));
         if res.is_err() {
             info!("Loadmeasurement_manager.measure_stack got error {:?}", res);
             return Err(res.err().unwrap());
@@ -320,52 +331,50 @@ pub fn Load(
         software_measurement= measurement_manager.get_measurement().unwrap();
     }
 
-    let app_name;
-    let app_loaded;
 
-    {
-        let app_info_keeper = APPLICATION_INFO_KEEPER.read();
-
-        app_name = app_info_keeper.get_application_name().unwrap().to_string();
-        app_loaded = app_info_keeper.is_application_loaded().unwrap();
-    }
 
     info!("Load app_name {:?}, name {:?}, app_loaded {:?}, process id {:?}", app_name, name, app_loaded, task.Thread().ThreadGroup().ID());
       
-    // trigger remote attestation and secret provisioning if the kernel is going to launch application binary
-    if app_name.eq(name) && !app_loaded {
 
-
+    if app_name.eq(name){
         debug!("Load attestation begin, the software measurement is {:?}", software_measurement);
 
-        // attestation, panic if attestation failed
-        let res = https_attestation_provisioning_cli::provisioning_http_client(task, &software_measurement);
-        if res.is_err() {
-            info!("https_attestation_provisioning_cli::provisioning_http_client(task) got error {:?}", res);
-            return Err(res.err().unwrap());
-        }
-
-        let (shield_policy, secret) = res.unwrap();
-        // updata the policy
-        policy_provisioning(&shield_policy).unwrap();
-
-        // secret injection
-
-        guest_syscall_interceptor::syscall_interceptor_init(shield_policy.syscall_interceptor_config.clone(),  task.Thread().ThreadGroup().ID()).unwrap();
-
-        // file based secret injection
-        {
-            let mut secret_injector =  SECRET_KEEPER.write();
-
-            let res = secret_injector.bookkeep_file_based_secret(secret.clone());
+        // trigger remote attestation and secret provisioning when the kernel is going to launch application binary first time
+        // skip if application is restarted
+        if !app_loaded {
+            let res = https_attestation_provisioning_cli::provisioning_http_client(task, &software_measurement);
             if res.is_err() {
-                info!("Load: failed to call file_based_secret_injection");
+                info!("https_attestation_provisioning_cli::provisioning_http_client(task) got error {:?}", res);
+                return Err(res.err().unwrap());
+            }
+    
+            let (shield_policy, secret) = res.unwrap();
+            // updata the policy
+            policy_provisioning(&shield_policy).unwrap();
+
+            guest_syscall_interceptor::syscall_interceptor_init(shield_policy.syscall_interceptor_config.clone()).unwrap();
+
+            {
+                let mut secret_injector =  SECRET_KEEPER.write();
+    
+                let res = secret_injector.bookkeep_secrets(secret.clone());
+                if res.is_err() {
+                    info!("Load: failed to call file_based_secret_injection");
+                }
             }
         }
 
+        // attestation, panic if attestation failed
+        // secret injection
+        guest_syscall_interceptor::syscall_interceptor_set_app_pid(task.Thread().ThreadGroup().ID()).unwrap();
+
+        // file based secret injection
+
+        let env_arg_secret;
         {
             let secret_injector = SECRET_KEEPER.read();
             let res = secret_injector.inject_file_based_secret_to_secret_file_system(task);
+            env_arg_secret= secret_injector.arg_env_based_secrets.clone();
 
             if res.is_err() {
                 info!("Load: failed to set up file system for secrets on guest memory");
@@ -373,9 +382,9 @@ pub fn Load(
         }
 
         // env based secret injection
-        if secret.env_cmd_secrets.is_some() {
+        if env_arg_secret.is_some() {
 
-            let cmd_envs = secret.env_cmd_secrets.as_ref().unwrap();
+            let cmd_envs = env_arg_secret.as_ref().unwrap();
             let mut env_secrets = cmd_envs.env_variables.clone();
             envv.append(&mut env_secrets);
     
@@ -384,7 +393,6 @@ pub fn Load(
             argv.append(&mut arg_secrets);
 
         }
-
 
         {
             let mut  app_info_keeper = APPLICATION_INFO_KEEPER.write();

--- a/qvisor/Cargo.lock
+++ b/qvisor/Cargo.lock
@@ -203,6 +203,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,6 +225,12 @@ name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bindgen"
@@ -462,6 +474,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
+
+[[package]]
 name = "containerd-shim"
 version = "0.3.0"
 source = "git+https://github.com/QuarkContainer/rust-extensions.git#b3ac82d9cc2a2674543118bb282537d132870c1a"
@@ -546,6 +564,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -649,6 +679,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,6 +728,7 @@ checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -715,6 +757,40 @@ name = "dtoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
+
+[[package]]
+name = "ecdsa"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12844141594ad74185a926d030f3b605f6a903b4e3fec351f3ea338ac5b7637e"
+dependencies = [
+ "der",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "der",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -776,6 +852,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -994,6 +1080,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,6 +1129,24 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -1549,6 +1664,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "p384"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630a4a9b2618348ececfae61a4905f564b817063bf2d66cdfc2ced523fe1d2d4"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "parking"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1593,6 +1720,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1609,6 +1745,16 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -1656,6 +1802,15 @@ checksum = "059a34f111a9dee2ce1ac2826a68b24601c4298cfeb1a587c3cb493d5ab46f52"
 dependencies = [
  "libc",
  "nix 0.26.2",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b54f7131b3dba65a2f414cf5bd25b66d4682e4608610668eae785750ba4c5b2"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -1769,6 +1924,7 @@ dependencies = [
  "num_cpus",
  "oci-spec",
  "os_pipe",
+ "p384",
  "prctl",
  "procfs",
  "rand 0.7.3",
@@ -1992,6 +2148,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+dependencies = [
+ "crypto-bigint",
+ "hmac",
+ "zeroize",
+]
+
+[[package]]
 name = "ringbuf"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2041,6 +2208,20 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -2208,6 +2389,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simplelog"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2256,6 +2447,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -2975,3 +3176,9 @@ name = "zero"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f1bc8a6b2005884962297587045002d8cfb8dcec9db332f4ca216ddc5de82c5"
+
+[[package]]
+name = "zeroize"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"

--- a/qvisor/src/shield/guest_syscall_interceptor.rs
+++ b/qvisor/src/shield/guest_syscall_interceptor.rs
@@ -14,7 +14,7 @@ pub struct GuestSyscallInterceptor {
 }
 
 
-pub fn syscall_interceptor_init(_policy: BackEndSyscallInterceptorConfig, _application_pid: i32) -> Result<()> {
+pub fn syscall_interceptor_init(_policy: BackEndSyscallInterceptorConfig) -> Result<()>{
     Err(Error::NotSupport)
 }
 
@@ -22,6 +22,11 @@ pub fn syscall_interceptor_init(_policy: BackEndSyscallInterceptorConfig, _appli
 // TODO: ENABLE CONTEXT BASED SYSTEM CALL INTERCEPTOR
 pub fn is_guest_syscall_allowed(_current_pid: i32, _syscall_id: u64) -> bool {
     false
+}
+
+
+pub fn syscall_interceptor_set_app_pid(_application_pid: i32) -> Result<()> {
+    Err(Error::NotSupport)
 }
 
 

--- a/qvisor/src/shield/secret_injection.rs
+++ b/qvisor/src/shield/secret_injection.rs
@@ -8,6 +8,7 @@ use  crate::qlib::kernel::fs::mount::MountNs;
 use crate::qlib::common::*;
 use alloc::collections::btree_map::BTreeMap;
 use alloc::string::String;
+use crate::EnvCmdBasedSecrets;
 
 lazy_static! {
     pub static ref SECRET_KEEPER:  RwLock<SecretKeeper> = RwLock::new(SecretKeeper::default());
@@ -20,6 +21,7 @@ pub struct SecretKeeper {
     initialized: bool,
     secrets_mount_info: FileSystemMount,
     pub file_secrets:  BTreeMap<String, Vec<u8>>,  // key: file name, value: secret
+    pub arg_env_based_secrets: Option<EnvCmdBasedSecrets>,
 }
 
 
@@ -30,7 +32,7 @@ impl SecretKeeper {
 
 
 
-    pub fn bookkeep_file_based_secret (&mut self, _secrets: KbsSecrets) -> Result<()> {
+    pub fn bookkeep_secrets (&mut self, _secrets: KbsSecrets) -> Result<()> {
         Err(Error::NotSupport)
     }
 

--- a/qvisor/src/shield/software_measurement_manager.rs
+++ b/qvisor/src/shield/software_measurement_manager.rs
@@ -54,7 +54,7 @@ impl SoftwareMeasurementManager {
      *  Only measure the auxv we got from elf file is enough,
      *  Other data like, envv, argv, are measuared by `measure_process_spec`
      */
-    pub fn measure_stack(&mut self, _auxv: Vec<AuxEntry>) -> Result<()> {
+    pub fn measure_stack(&mut self, _auxv: Vec<AuxEntry>, _is_app: bool) -> Result<()> {
         Err(Error::NotSupport)
     }
 


### PR DESCRIPTION
When the container process crashes unexpectedly, k8s will notify qkenel to try to restart the container. At this point, qkernel will create a new process and load the container's executable file into the address space of that process. To prevent corrupt viable files from being loaded, qkernel will record the process of reloading the container and compare it with the process of loading the container for the first time. If the hash values of the two loading processes do not match, this will result in a qkernel panic“